### PR TITLE
Publish to umd and update tsconfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
     "sinon": "1.17.3",
     "sinon-chai": "2.8.0",
     "tslint": "3.11.0",
-    "typescript": "1.8.10",
-    "typescript-assistant": "0.6.8",
-    "typescript-formatter": "2.2.0",
+    "typescript": "2.0.10",
+    "typescript-assistant": "0.6.10",
+    "typescript-formatter": "4.0.1",
     "vinyl-buffer": "1.0.0",
     "vinyl-source-stream": "1.1.0"
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,13 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
+        "module": "umd",
         "target": "es5",
         "noImplicitAny": true,
         "outDir": "build/js",
         "rootDir": ".",
         "sourceMap": true,
-        "noEmitOnError": true
+        "noEmitOnError": true,
+        "moduleResolution": "node"
     },
     "exclude": [
         "node_modules",
@@ -17,7 +18,7 @@
         ".idea",
         ".c9"
     ],
-    "filesGlob": [
+    "include": [
         "./src/**/*.ts",
         "./test/**/*.ts",
         "./typings/**/*.ts"


### PR DESCRIPTION
Fixes: https://github.com/AFASSoftware/maquette-query/issues/8

- Updates `package.json` dependencies
- Updates `tsconfig`
   - `includes` instead of `filesGlob`
   - `moduleResolution` changed to `node`
   - `module` changed to `umd`

`gulp test` and `gulp dist` passing.
